### PR TITLE
Remove ads in group pictures

### DIFF
--- a/content.js
+++ b/content.js
@@ -23,6 +23,9 @@
 
 		// mobile version
 		$("article.acw").remove();
+
+		// Ads in group pictures
+		$(".rhcFooter").hide();
 	}
 	var throttled = _.throttle(remove_ads, 1000);
 


### PR DESCRIPTION
![screenshot from 2017-02-08 02-04-50](https://cloud.githubusercontent.com/assets/1937689/22704697/8e51b816-eda3-11e6-94ce-52c0020d3e0e.png)

See the right-bottom corner. Sometimes there are ads in group pictures if there are not many comments.