### PR TITLE
Explicit states that Facebook is a registered trademark

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "Facebook Adblock",
-    "version": "1.1.8",
+    "name": "Ad Blocker for Facebook™",
+    "version": "1.1.9",
     "manifest_version": 2,
     "description": "Blocking Facebook Ads",
     "homepage_url": "https://github.com/tiratatp/facebook_adblock",


### PR DESCRIPTION
I've just checked on addons.mozilla.org, and lots of addon names use this pattern "XXX for Facebook (TM)". [1] I feel such a pattern is more like daily English and it should be safer w.r.t. DMCA things.

For Ad Block => Ad Blocker: that's the name recommended by Eyeo GmbH (the company behind adblockplus). I'd like to solve two issues at the same time.

I'll upload this version to Mozilla first. If you have a better name, just change it and commit 1.1.10 (Mozilla disallows overwriting addons with the same version)

[1] https://addons.mozilla.org/en-US/firefox/search/?q=facebook&appver=51.0&platform=linux