### PR TITLE
Add feed__sub__title to possibleSponsoredTextQueries

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ const sponsoredTexts = [
 
 const possibleSponsoredTextQueries = [
   'div[id^="feed_sub_title"] > :first-child',
+  'div[id^="feed__sub__title"] > :first-child',
   'div[data-testid="story-subtitle"] > :first-child',
   'div[id^="feedsubtitle"] > :first-child',
 ];


### PR DESCRIPTION
Today I noticed that Facebook started using "feed__sub__title" (with two underscores) for some sponsored elements.

For now, I just added that prefix to the list. However, I wouldn't be surprised if later on they start adding an arbitrary amount of underscores. In that case maybe we should consider using a regex or something else.