### PR TITLE
Add story-subtilte data attribute to possibleSponsoredTextQueries

### DIFF
--- a/dist/chrome/content.js
+++ b/dist/chrome/content.js
@@ -732,7 +732,7 @@
 	'ได้รับการสนับสนุน', // Thai
 	'Sponsorlu', // Turkish
 	'Được tài trợ'];
-	const possibleSponsoredTextQueries = ['div[id^="feedsubtitle"] > :first-child', 'div[id^="feed_sub_title"] > :first-child', 'div[id^="feed__sub__title"] > :first-child', 'div[data-testid="story-subtitle"] > :first-child'];
+	const possibleSponsoredTextQueries = ['div[id^="feedsubtitle"] > :first-child', 'div[id^="feed_sub_title"] > :first-child', 'div[id^="feed__sub__title"] > :first-child', 'div[data-testid$="story-subtitle"] > :first-child', 'div[data-testid$="story-subtilte"] > :first-child'];
 
 	function isHidden(e) {
 	  const style = window.getComputedStyle(e);

--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,8 @@ const possibleSponsoredTextQueries = [
   'div[id^="feedsubtitle"] > :first-child',
   'div[id^="feed_sub_title"] > :first-child',
   'div[id^="feed__sub__title"] > :first-child',
-  'div[data-testid="story-subtitle"] > :first-child',
+  'div[data-testid$="story-subtitle"] > :first-child',
+  'div[data-testid$="story-subtilte"] > :first-child',
 ];
 
 function isHidden(e) {


### PR DESCRIPTION
The data attribute deliberately uses a typo in its value.

Specifically I found:
``<div class="_5pcp _5lel _2jyu _232_" data-testid="testid--story-subtilte">``