### PR TITLE
Add facebookcorewwwi.onion to domain matches

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -11,7 +11,10 @@
   "homepage_url": "https://github.com/tiratatp/facebook_adblock",
   "content_scripts": [
     {
-      "matches": ["*://*.facebook.com/*"],
+      "matches": [
+        "*://*.facebook.com/*"
+        "*://*.facebookcorewwwi.onion/*"
+      ],
       "css": ["content.css"],
       "js": ["content.js"],
       "run_at": "document_idle"


### PR DESCRIPTION
Hey @tiratatp I've been a happy user of this extension for a while now. Since Facebook offers an [onion domain to browse their website](https://en.wikipedia.org/wiki/Facebookcorewwwi.onion), I occasionally use, I thought of adding it to the list of domains matches.