### PR TITLE
Add m.facebook.com domain match

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -11,7 +11,7 @@
   "homepage_url": "https://github.com/tiratatp/facebook_adblock",
   "content_scripts": [
     {
-      "matches": ["*://*.facebook.com/*", "*://*.facebookcorewwwi.onion/*"],
+      "matches": ["*://*.facebook.com/*", "*://*.facebookcorewwwi.onion/*", "*://*.m.facebook.com/*"],
       "css": ["content.css"],
       "js": ["content.js"],
       "run_at": "document_idle"


### PR DESCRIPTION
Hey, I noticed the addon can be installed on mobile as well, yet it's not activated in `m.facebook.com` domain so I thought I'll suggest adding it.