### PR TITLE
block sponsored and suggested posts

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ const sponsoredTexts = [
   "May Sponsor", // Filipino
   "Sponsorisé", // French
   "Gesponsert", // German
+  "Χορηγούμενη", // Greek
   "ממומן", // Hebrew
   "प्रायोजित", // Hindi
   "Bersponsor", // Indonesian

--- a/src/main.js
+++ b/src/main.js
@@ -105,6 +105,15 @@ function hideIfSponsored(e) {
     return true; // has ad
   }
 
+  if ( // If it does NOT have a timestamp due to "Sponsored" label
+    !e.querySelector('div[id^=fbfeed_sub_header_id] abbr')
+  ) {
+    e.style.display='none';
+    e.dataset.blocked='sponsored'
+    console.info(`AD Blocked (!div[id^=fbfeed_sub_header_id] abbr)`, [e]);
+    return true;
+  }
+
   return possibleSponsoredTextQueries.some((query) => {
     const result = e.querySelectorAll(query);
     return [...result].some(t => {

--- a/src/main.js
+++ b/src/main.js
@@ -83,6 +83,7 @@ function hideIfSponsored(e) {
   if (
     whitelist.some((query) => {
       if (e.querySelector(query) !== null) {
+        e.dataset.blocked='whitelist'
         console.info(`Ignored (${query})`, [e]);
         return true;
       }
@@ -96,6 +97,7 @@ function hideIfSponsored(e) {
     blacklist.some((query) => {
       if (e.querySelector(query) !== null) {
         e.style.display = "none";
+        e.dataset.blocked='blacklist'
         console.info(`AD Blocked (${query})`, [e]);
         return true;
       }
@@ -124,6 +126,7 @@ function hideIfSponsored(e) {
         )
       ) {
         e.style.display = "none";
+        e.dataset.blocked='sponsored'
         console.info(`AD Blocked (${query}, getVisibleText())`, [e]);
         return true;
       }


### PR DESCRIPTION
I've added:
- the Greek label for sponsoredText search
- an extra check to block ads based on the absence of time info due to "Sponsored" label
- a blacklist check for "Suggested for you" content
- data-blocked attribute for debugging

---
### Debugging
`data-blocked` attribute values:
* `whitelist`: whitelisted
* `blacklist`: blocked due to blacklist check
* `sponsored`: blocked due to sponsored label

You can debug using javascript from dev tools console:
`document.querySelectorAll('*[data-blocked]');`
`document.querySelectorAll('*[data-blocked="sponsored"]');`
```
document.querySelectorAll('*[data-blocked="sponsored"]').forEach(x=>{
  x.style.display="inherit";
  x.style.border="red 10px solid";
});
```
You can also inject css:
```
*[data-blocked] {
    display: inherit !important;
    border: red 10px solid;
}
*[data-blocked="sponsored"] {
    border-color: darkorange;
}
*[data-blocked="whitelist"] {
    border-color: green;
}
```
