### PR TITLE
Fix looped loading

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -107,15 +107,6 @@ function hideIfSponsored(e) {
     return true; // has ad
   }
 
-  if ( // If it does NOT have a timestamp due to "Sponsored" label
-    !e.querySelector('div[id^=fbfeed_sub_header_id] abbr')
-  ) {
-    e.style.display='none';
-    e.dataset.blocked='sponsored'
-    console.info(`AD Blocked (!div[id^=fbfeed_sub_header_id] abbr)`, [e]);
-    return true;
-  }
-
   return possibleSponsoredTextQueries.some((query) => {
     const result = e.querySelectorAll(query);
     return [...result].some(t => {


### PR DESCRIPTION
Facebook changed the feed element structure and now the timestamp is no longer in a abbr element but scrambled with spans.

This reverts commit 216fc27a6d8556d97e40ade0215042fa71037cc5.

fixes issue https://github.com/tiratatp/facebook_adblock/issues/50