### PR TITLE
Added new sponsored posts detection

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -120,7 +120,7 @@ function hideIfSponsored(e) {
       ) {
         e.style.display = "none";
         e.dataset.blocked='sponsored'
-        console.info(`AD Blocked (${query}, getVisibleText())`, [e]);
+        console.info(`AD Blocked (${query}, getVisibleText(${visibleText}))`, [e]);
         return true;
       }
       return false;
@@ -184,6 +184,7 @@ if (fbContent !== undefined) {
   fbObserver.observe(fbContent, {
     childList: true,
   });
+  console.info("Monitoring page changes", [fbContent]);
 }
 
 // cleanup

--- a/src/main.js
+++ b/src/main.js
@@ -85,7 +85,7 @@ function hideIfSponsored(e) {
   if (
     whitelist.some((query) => {
       if (e.querySelector(query) !== null) {
-        e.dataset.blocked='whitelist'
+        e.dataset.blocked = 'whitelist';
         console.info(`Ignored (${query})`, [e]);
         return true;
       }
@@ -99,7 +99,7 @@ function hideIfSponsored(e) {
     blacklist.some((query) => {
       if (e.querySelector(query) !== null) {
         e.style.display = "none";
-        e.dataset.blocked='blacklist'
+        e.dataset.blocked = 'blacklist';
         console.info(`AD Blocked (${query})`, [e]);
         return true;
       }
@@ -119,7 +119,7 @@ function hideIfSponsored(e) {
         )
       ) {
         e.style.display = "none";
-        e.dataset.blocked='sponsored'
+        e.dataset.blocked = 'sponsored';
         console.info(`AD Blocked (${query}, getVisibleText(${visibleText}))`, [e]);
         return true;
       }

--- a/src/main.js
+++ b/src/main.js
@@ -46,6 +46,8 @@ const possibleSponsoredTextQueries = [
   'div[data-testid$="story-subtilte"] > :first-child',
   'div[data-testid$="story--subtilte"] > :first-child',
   'div[data-testid*="label"] > :first-child',
+  'div[id^="fbfeed_sub_header_id"] > :nth-child(3)',
+  'a[role="button"][aria-labelledby]',
 ];
 
 function isHidden(e) {


### PR DESCRIPTION
This PR includes the classic facebook changes that were part of PR https://github.com/tiratatp/facebook_adblock/pull/54. Just in case you want to release a new version without the FB5 support