### PR TITLE
Block political ads

### DIFF
--- a/src/fb5.js
+++ b/src/fb5.js
@@ -3,7 +3,7 @@ import __hideIfSponsored from "./hide_if_sponsored";
 const possibleSponsoredTextQueries = [
   'a[role="link"] > span[aria-labelledby]',
   'div[role="button"] > span[aria-labelledby]',
-  'div[role="button"]',
+  'span[dir="auto"] > span > div[role="button"]:not([aria-labelledby])',
 ];
 
 function hideIfSponsored(e) {

--- a/src/fb5.js
+++ b/src/fb5.js
@@ -3,6 +3,7 @@ import __hideIfSponsored from "./hide_if_sponsored";
 const possibleSponsoredTextQueries = [
   'a[role="link"] > span[aria-labelledby]',
   'div[role="button"] > span[aria-labelledby]',
+  'div[role="button"]',
 ];
 
 function hideIfSponsored(e) {


### PR DESCRIPTION
[Ads about social issues, elections or politics](https://www.facebook.com/business/help/167836590566506) are shown differently than regular ads:

![image](https://user-images.githubusercontent.com/1872963/111868041-6350f000-8980-11eb-9c81-39e30ff995f9.png)

Filtering all `div[role="button"]` elements for the `Sponsored` text will remove these posts from the newsfeed. I know this filter is broad and will cause going through many elements, but I couldn't find a more specific selector.